### PR TITLE
Changed to wait_for_active_shards in bulk for ES 5.x compat.

### DIFF
--- a/lib/logship.js
+++ b/lib/logship.js
@@ -363,7 +363,7 @@ PostfixToElastic.prototype.saveResultsToEs = function(done) {
   });
 
   // logger.info(esBulk);
-  p2e.elastic.bulk({ body: esBulk, consistency: 'all' }, function (err, res) {
+  p2e.elastic.bulk({ body: esBulk, wait_for_active_shards : 1 }, function (err, res) {
     if (err) return done(err);
     if (res.errors) {
       logger.info(util.inspect(res, { depth: null }));


### PR DESCRIPTION
consistency: 'all'  no longer used in ES 5.x . 
Using wait_for_active_shards : 1 .
